### PR TITLE
bugfix: incomplete buffer flushing when using duplex type connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+/main
+/build
+/bin
+/testresults
 /vendor


### PR DESCRIPTION
When the network or hardware is slow enough the final bytes could be left off and RST backets over tcp were being sent.

This resolves that complication.