### PR TITLE
remove unixpacket support - it never worked properly

### DIFF
--- a/cmd/redir/main.go
+++ b/cmd/redir/main.go
@@ -21,7 +21,7 @@ import (
 
 // build-time vars
 var (
-	version = "v1.1.9"
+	version = "v1.2.0"
 )
 
 type dialerFunc = func(context.Context) (net.Conn, error)
@@ -566,7 +566,7 @@ func handleCon(ctx context.Context, logger *slog.Logger, dialer dialerFunc, from
 }
 
 func allowedNets() []string {
-	return []string{"tcp", "tcp4", "tcp6", "unix", "unixpacket"}
+	return []string{"tcp", "tcp4", "tcp6", "unix"}
 }
 
 func errAttr(err error) slog.Attr {


### PR DESCRIPTION
Disallows unix-packet style networks. Their external data-link equivalent is a datagram packet and the current implementation flat out does not work with that at the moment.

I do not consider this a breaking change because the execution path was already completely broken.
Semantically I should bump the major version. I'm going to instead opt for bumping the minor one.